### PR TITLE
Enable setting extra_specs when creating volume types

### DIFF
--- a/cinderclient/v1/volume_types.py
+++ b/cinderclient/v1/volume_types.py
@@ -105,7 +105,7 @@ class VolumeTypeManager(base.ManagerWithFind):
         """
         self._delete("/types/%s" % base.getid(volume_type))
 
-    def create(self, name):
+    def create(self, name, extra_specs={}):
         """
         Create a volume type.
 
@@ -116,6 +116,7 @@ class VolumeTypeManager(base.ManagerWithFind):
         body = {
             "volume_type": {
                 "name": name,
+                "extra_specs": extra_specs
             }
         }
 

--- a/cinderclient/v2/volume_types.py
+++ b/cinderclient/v2/volume_types.py
@@ -92,7 +92,7 @@ class VolumeTypeManager(base.ManagerWithFind):
         """
         self._delete("/types/%s" % base.getid(volume_type))
 
-    def create(self, name):
+    def create(self, name, extra_specs={}):
         """Create a volume type.
 
         :param name: Descriptive name of the volume type
@@ -102,6 +102,7 @@ class VolumeTypeManager(base.ManagerWithFind):
         body = {
             "volume_type": {
                 "name": name,
+                "extra_specs": extra_specs
             }
         }
 


### PR DESCRIPTION
Add optional `extra_specs` kwarg for VolumeTypeManager.create method, in v1 and v2
