### PR TITLE
docs: Fix a few typos

### DIFF
--- a/cinderclient/shell.py
+++ b/cinderclient/shell.py
@@ -647,7 +647,7 @@ class OpenStackCinderShell(object):
 
         # NOTE(e0ne): if auth_session exists it means auth plugin created
         # session and we don't need to check for password and other
-        # authentification-related things.
+        # authentication-related things.
         if not utils.isunauthenticated(args.func) and not auth_session:
             if not os_password:
                 # No password, If we've got a tty, try prompting for it

--- a/cinderclient/tests/unit/test_shell.py
+++ b/cinderclient/tests/unit/test_shell.py
@@ -108,7 +108,7 @@ class ShellTest(utils.TestCase):
         _shell = shell.OpenStackCinderShell()
 
         # We crash the command after Client instantiation because this test
-        # focuses only keystoneauth1 indentity cli opts parsing.
+        # focuses only keystoneauth1 identity cli opts parsing.
         self.assertRaises(RuntimeError, _shell.main, ['list'])
         self.assertIsInstance(_shell.cs.client.session.auth,
                               ks_password)

--- a/cinderclient/utils.py
+++ b/cinderclient/utils.py
@@ -68,7 +68,7 @@ def add_arg(f, *args, **kwargs):
 
 
 def add_exclusive_arg(f, group_name, required, *args, **kwargs):
-    """Bind CLI mutally exclusive arguments to a shell.py `do_foo` function."""
+    """Bind CLI mutually exclusive arguments to a shell.py `do_foo` function."""
 
     if not hasattr(f, 'exclusive_args'):
         f.exclusive_args = collections.defaultdict(list)


### PR DESCRIPTION
There are small typos in:
- cinderclient/shell.py
- cinderclient/tests/unit/test_shell.py
- cinderclient/utils.py

Fixes:
- Should read `mutually` rather than `mutally`.
- Should read `identity` rather than `indentity`.
- Should read `authentication` rather than `authentification`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md